### PR TITLE
Added Android Development Settings, better UI colors, and fixed DNS hostnames 

### DIFF
--- a/app/src/main/java/com/threethan/questhiddensettings/MainActivity.kt
+++ b/app/src/main/java/com/threethan/questhiddensettings/MainActivity.kt
@@ -78,7 +78,7 @@ class MainActivity : AppCompatActivity() {
 
         accessibilityBtn.setOnClickListener {
             val builder = AlertDialog.Builder(this)
-            builder.setTitle("Notice")
+            builder.setTitle("Notice!")
             builder.setMessage(
                 "Many of the settings here don't work.\n"+
                 "You can enable mono audio or adjust balance,\n"+
@@ -88,6 +88,23 @@ class MainActivity : AppCompatActivity() {
             )
             builder.setPositiveButton("Continue") { _, _ ->
                 settingsActivity("AccessibilitySettingsActivity")
+            }
+            builder.setNegativeButton("Cancel") { _, _ -> }
+            builder.create().show()
+        }
+
+        devBtn.setOnClickListener {
+            val builder = AlertDialog.Builder(this)
+            builder.setTitle("Notice!")
+            builder.setMessage(
+                "Many of the settings in here don't work or could potentially harm your device, \n"+
+                "Do NOT continue unless you know what you are doing. \n"+
+                "Button not working? \n"+
+                "Try going to Device Info and pressing on the build number 10 times.\n\n"+
+                "Use the Quest's developer settings for stuff like unlocking the bootloader."
+            )
+            builder.setPositiveButton("Continue") { _, _ ->
+                settingsActivity("DevelopmentSettingsDashboardActivity")
             }
             builder.setNegativeButton("Cancel") { _, _ -> }
             builder.create().show()

--- a/app/src/main/java/com/threethan/questhiddensettings/MainActivity.kt
+++ b/app/src/main/java/com/threethan/questhiddensettings/MainActivity.kt
@@ -35,7 +35,7 @@ class MainActivity : AppCompatActivity() {
 
         dnsBtn.setOnClickListener {
             val items = arrayOf<CharSequence>("AdGuard DNS (Blocks Ads, Recommended)", "Cloudflare DNS (Fast)", "Quad9 (Private)", "Google DNS")
-            val hostnames = arrayOf<CharSequence>("dns.adguard.com", "1dot1dot1dot1.cloudflare-dns.com", "dns.google")
+            val hostnames = arrayOf<CharSequence>("dns.adguard-dns.com", "one.one.one.one", "dns11.quad9.net", "dns.google")
 
             val builder = AlertDialog.Builder(this)
             builder.setTitle("Select a DNS provider")

--- a/app/src/main/res/drawable-v24/buttonbg.xml
+++ b/app/src/main/res/drawable-v24/buttonbg.xml
@@ -3,7 +3,7 @@
     <item>
         <shape xmlns:android="http://schemas.android.com/apk/res/android" android:shape="rectangle">
             <corners android:radius="4dp" />
-            <color android:color="#034abe" />
+            <color android:color="#6985E1" />
         </shape>
     </item>
 </selector>

--- a/app/src/main/res/drawable/windowbg.xml
+++ b/app/src/main/res/drawable/windowbg.xml
@@ -4,6 +4,6 @@
         <shape android:shape="rectangle">
             <corners android:radius="20dp" />
         </shape>
-        <color android:color="#131314" />
+        <color android:color="#212328" />
     </item>
 </selector>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -138,4 +138,27 @@
         android:text="@string/acessibilityDesc"
         android:textColor="#FFFFFF" />
 
+        <Button
+        android:id="@+id/devBtn"
+        android:layout_width="360dp"
+        android:layout_height="44dp"
+
+        android:layout_marginTop="10dp"
+        android:background="@drawable/buttonbg"
+        android:backgroundTint="@color/ic_banner_background"
+        android:backgroundTintMode="multiply"
+        android:text="@string/dev"
+        android:textAlignment="center"
+        android:textSize="18sp"
+        android:textStyle="bold"
+        android:typeface="normal" />
+
+    <TextView
+        android:id="@+id/devTxt"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:text="@string/devDesc"
+        android:textColor="#FFFFFF" />
+
 </LinearLayout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -26,4 +26,7 @@
     <string name="info">Device Info</string>
     <string name="infoDesc">View device info and set device name</string>
 
+    <string name="dev">Developer Settings</string>
+    <string name="devDesc">Access the developer settings or unlock the bootloader</string>
+    
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -2,11 +2,13 @@
     <!-- Base application theme. -->
     <style name="Theme.Oculus" parent="Theme.MaterialComponents.DayNight.NoActionBar">
         <!-- Primary brand color. -->
-        <item name="colorPrimary">#024abf</item>
+        <item name="colorPrimary">#6985E1</item>
+        <item name="colorPrimaryVariant">#5069BA</item>
+        <item name="colorPrimaryDark">#5069BA</item>
         <item name="colorOnPrimary">#ffffff</item>
 
         <!-- Customize your theme here. -->
-        <item name="android:windowBackground">"#121214"</item>
+        <item name="android:windowBackground">"#212328"</item>
         <item name="android:windowContentOverlay">@null</item>
         <item name="android:windowNoTitle">true</item>
     </style>


### PR DESCRIPTION
I added a button that opens the systems development settings and it can used to unlock the bootloader by ticking "OEM Unlocking" on. I changed the UI colors to be not as harsh and partially inspired by Discord, updated the DNS hostnames you had because they have changed since they were originally added, and fixed the DNS for Quad9 as the name was in the list but no DNS was set for it.

Let me know if it works, I can't compile it because I don't have any android SDK's setup on my pc right now but in theory it should work.

I also have a new icon for you that I didnt include in here, if you're interested hit me up on discord.

Discord: lonk1639
![ic_launcher-playstore (1)](https://github.com/threethan/QuestHiddenSettings/assets/51008428/9a7b1bb7-fe21-48a9-987b-50a037ab979e)
